### PR TITLE
fix: lazy initialize API clients to prevent build failures in CI

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -283,10 +283,20 @@ What would you like to know?`,
   };
 }
 
-// Initialize OpenAI client
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || ""
-});
+// Initialize OpenAI client lazily to avoid build-time errors when env vars are missing
+let openai: OpenAI | null = null;
+
+function getOpenAIClient(): OpenAI {
+  if (!openai) {
+    if (!process.env.OPENAI_API_KEY) {
+      throw new Error("OPENAI_API_KEY is not configured");
+    }
+    openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY
+    });
+  }
+  return openai;
+}
 
 // Create system prompt from knowledge base
 const SYSTEM_PROMPT = `You are a helpful assistant answering questions about Andor Kesselman's professional work and background.
@@ -372,7 +382,7 @@ export async function POST(request: NextRequest) {
     ];
 
     // Call OpenAI
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAIClient().chat.completions.create({
       model: "gpt-4o-mini",
       messages,
       temperature: 0.7,

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,7 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Initialize Resend lazily to avoid build-time errors when env vars are missing
+let resend: Resend | null = null;
+
+function getResendClient(): Resend {
+  if (!resend) {
+    if (!process.env.RESEND_API_KEY) {
+      throw new Error("RESEND_API_KEY is not configured");
+    }
+    resend = new Resend(process.env.RESEND_API_KEY);
+  }
+  return resend;
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -28,7 +39,7 @@ Message:
 ${message || "No message provided"}
     `.trim();
 
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await getResendClient().emails.send({
       from: "Contact Form <onboarding@resend.dev>",
       to: ["andor@agentoverlay.com"], // Using your verified Resend email
       subject: `New Contact Form Submission from ${name}`,


### PR DESCRIPTION
- Move OpenAI and Resend client initialization from module-level to lazy functions
- Prevents build-time errors when OPENAI_API_KEY and RESEND_API_KEY are not set
- Allows GitHub Actions to build successfully without env vars
- Runtime validation still ensures API keys are required when routes are called

Fixes build failure in GitHub Actions where env vars are not available during static page generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)