### PR TITLE
fix: correct ref callback type in services page

### DIFF
--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -32,7 +32,9 @@ export default function ServicePage() {
                   <div className="flex flex-col justify-center w-full">
                     <div className="group rounded-lg border border p-5 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30">
                       <span
-                        ref={(el) => (serviceRefs.current[index] = el)}
+                        ref={(el) => {
+                          serviceRefs.current[index] = el;
+                        }}
                         className="text-2xl font-bold"
                       >
                         {service.name}


### PR DESCRIPTION
The ref callback was using an assignment expression which returns a value, but TypeScript expects ref callbacks to return void or a cleanup function.

Changed from:
  ref={(el) => (serviceRefs.current[index] = el)}

To:
  ref={(el) => {
    serviceRefs.current[index] = el;
  }}

This fixes the TypeScript error:
  Type '(el: HTMLSpanElement | null) => HTMLSpanElement | null' is not assignable to type 'LegacyRef<HTMLSpanElement> | undefined'

🤖 Generated with [Claude Code](https://claude.com/claude-code)