### PR TITLE
fix: disable GitHub Pages deployment (using Vercel instead)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,18 @@
-# Sample workflow for building and deploying a Next.js site to GitHub Pages
+# GitHub Pages deployment disabled - using Vercel instead
+# This project has API routes that require server-side functionality
+# which is not supported by GitHub Pages (static hosting only)
 #
-# To get started with Next.js see: https://nextjs.org/docs/getting-started
+# To re-enable GitHub Pages deployment, you would need to:
+# 1. Remove API routes (src/app/api/*)
+# 2. Enable static export in next.config.js
+# 3. Update the upload path to use 'out' directory
 #
 name: Deploy Next.js site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
+  # Disabled - using Vercel for deployment
+  # push:
+  #   branches: ["main"]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
GitHub Pages only supports static sites, but this project now has API routes (/api/chat and /api/contact) that require server-side functionality. These routes need Node.js runtime which is available on Vercel but not on GitHub Pages.

This was causing the deployment to fail with:
  "tar: dist: Cannot open: No such file or directory"

The deployment is now handled by Vercel which supports:
- Server-side API routes
- Environment variables (OPENAI_API_KEY, RESEND_API_KEY)
- Automatic deployments from main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)